### PR TITLE
Security fix, prevent SQL Injection, XSS

### DIFF
--- a/inc/logindata.php
+++ b/inc/logindata.php
@@ -20,14 +20,13 @@ if($row<1){
    session_start();
      $_SESSION['user'] = $data['user'];
 
-     echo  $_SESSION['user'];
+     echo  htmlspecialchars($_SESSION['user']);
 }
 }
-function filter_data($data){
- $data = htmlspecialchars($data);
- $data = stripslashes($data);
- $data = trim($data);
- return $data;
+function filter_data($data){ // not for numeric!
+ global $con;
+ $safe_string = mysqli_real_escape_string($con, $data);
+ return $safe_string;
 }
 
 ?>


### PR DESCRIPTION
[*] SQL Injection
htmlspecialchars does not encode single quotes (') if ENT_QUOTES is not used.
echo htmlspecialchars("'"); // outputs: '
echo htmlspecialchars("'", ENT_QUOTES); // outputs : &#039;

htmlspecialchars is not for preventing SQL Injection, use prepared queries or for a quick fix use mysqli_real_escape_string instead.

[*] For preventing XSS, use htmlspecialchars() while printing $_SESSION['user']